### PR TITLE
convert down import statements to require()s in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uk-modulus-check",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "compilerOptions": {
-    "target": "ES2020",            
-    "module": "CommonJS",
-    "moduleResolution": "Node",    
     "esModuleInterop": true,       
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
When trying to use the package, some of our tools (including Jest, and Next *production build only* (development build works fine)) get confused by the `import` statement. To work around this, we will tell TSC to just compile it down to the oldschool require() style. The javascript ecosystem is a mess.

I've locally tested this change and it allows us to properly build the frontend app.